### PR TITLE
Final bugfix of the day (Deleting a Link).

### DIFF
--- a/src/components/link.cpp
+++ b/src/components/link.cpp
@@ -18,6 +18,9 @@ Link::Link(Schema *schema, LinkConfiguration *conf, LinkConnections connections)
 Link::~Link()
 {
     qDebug() << "Deleting Link";
+
+    this->connections.begin->removeConnectedLink(this);
+    this->connections.end->removeConnectedLink(this);
 }
 
 void Link::addLine()


### PR DESCRIPTION
- Link was being deleted but its connected items were keeping reference of the now deleted link. When an item updated positions, it tried to reference the link, causing undefined behavior.