### PR TITLE
getline function

### DIFF
--- a/src/window/simulation.cpp
+++ b/src/window/simulation.cpp
@@ -55,6 +55,45 @@ void usage(char *progname)
     exit(EXIT_FAILURE);
 }
 
+int getline(char **lineptr, size_t *n, FILE *stream)
+{
+    static char line[256];
+    char *ptr;
+    unsigned int len;
+
+    if (lineptr == NULL || n == NULL)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (ferror (stream))
+        return -1;
+
+    if (feof(stream))
+        return -1;
+
+    fgets(line,256,stream);
+
+    ptr = strchr(line,'\n');
+    if (ptr)
+        *ptr = '\0';
+
+    len = strlen(line);
+
+    if ((len+1) < 256)
+    {
+        ptr = (char*)realloc(*lineptr, 256);
+        if (ptr == NULL)
+            return(-1);
+        *lineptr = ptr;
+        *n = 256;
+    }
+
+    strcpy(*lineptr,line);
+    return(len);
+}
+
 static void hsv2rgb(double h, double s, double v, unsigned int *r, unsigned int *b, unsigned int *g)
 {
 


### PR DESCRIPTION
Somehow, minGW doesn't recognize getline function from stdio, so I added on my own.

Please, before accept this pull request: I don't know if it will work on linux, so try to add this getline function (if you're using linux) and see if it runs. If so, consider accepting this pull request.